### PR TITLE
Load the library secretly to omit explicit namespace usage

### DIFF
--- a/inst/book/data_standards.Rmd
+++ b/inst/book/data_standards.Rmd
@@ -2,6 +2,12 @@
 
 # DAISIEmainland data standards {#DAISIEmainland-data-standards}
 
+```{r message=FALSE, eval=FALSE}
+# Assume the reader knows to load the library,
+# so we do not need to include the namespace in the visible code examples
+library(DAISIEmainland)
+```
+
 ## Reasoning
 
 There are several data types used in this package. Some of them are novel to
@@ -19,9 +25,9 @@ To make sure the data types are correctly formatted there is a corresponding
 A list of 2 elements, `$ideal_multi_daisie_data` and
 `$empirical_multi_daisie_data`.
 Each of these elements is in the format `multi_daisie_data` (see below). This
-is the output of `DAISIEmainland::sim_island_with_mainland()`.
+is the output of `sim_island_with_mainland()`.
 
-Function to check if it is a `daisie_mainland_data` is `DAISIEmainland::check_daisie_mainland_data()`
+Function to check if it is a `daisie_mainland_data` is `check_daisie_mainland_data()`
 
 ### `multi_daisie_data` {#multi-daisie-data}
 
@@ -29,7 +35,7 @@ A list of `daisie_data` elements (see below). This is the data structure when th
 simulation is run for several replicates.
 
 Function to check if it is a `multi_daisie_data` is
-`DAISIEmainland::check_multi_daisie_data()`.
+`check_multi_daisie_data()`.
 
 ### `daisie_data` {#daisie-data}
 
@@ -46,31 +52,31 @@ subsequent branching times (all given in time before the present).
 `daisie_data` is a single element of a `multi_daisie_data` list.
 
 Function to check if it is a `daisie_data` is
-`DAISIEmainland::check_daisie_data()`.
+`check_daisie_data()`.
 
 ### `multi_mainland_clade` {#multi-mainland-clade}
 
-A list of `mainland_clade` objects. This data type is output from `DAISIEmainland::sim_mainland()`.
+A list of `mainland_clade` objects. This data type is output from `sim_mainland()`.
 
 Function to check if it is a `multi_mainland_clade` is
-`DAISIEmainland::check_multi_mainland_clade()`.
+`check_multi_mainland_clade()`.
 
 ### `mainland_clade` {#mainland-clade}
 
 A data frame of seven columns and one or more rows. The column names are:
   `spec_id`, `main_anc_id`, `spec_type`, `branch_code`, `branch_t`,
 `spec_origin_t`, `spec_ex_t`. A example of an `mainland_clade` can be created
-using `DAISIEmainland::create_test_mainland_clade()`.
+using `create_test_mainland_clade()`.
 
 Function to check if it is a mainland_clade is
-`DAISIEmainland::check_mainland_clade()`
+`check_mainland_clade()`
 
 ### `island_tbl` {#island-tbl}
 
 * A data frame of the island species output from `sim_island` and then converted
 to the `daisie_data` format by `create_island`. This data type is output from
-`DAISIEmainland::sim_island()`. A example of an `island_tbl` can be created
-using `DAISIEmainland::create_test_island_tbl()`.
+`sim_island()`. A example of an `island_tbl` can be created
+using `create_test_island_tbl()`.
 
 Function to check if it is a `island_tbl` is
-`DAISIEmainland::check_island_tbl()`.
+`check_island_tbl()`.

--- a/inst/book/inference_performance.Rmd
+++ b/inst/book/inference_performance.Rmd
@@ -19,6 +19,12 @@ pre[class] {
 }
 ```
 
+```{r message=FALSE, eval=FALSE}
+# Assume the reader knows to load the library,
+# so we do not need to include the namespace in the visible code examples
+library(DAISIEmainland)
+```
+
 One of the primary purposes of the `DAISIEmainland` package and specifically
 why the data is formatted in the `DAISIE` format is to test the maximum 
 likelihood inference models implemented in the `DAISIE` R package [@etienne_daisie_2022]. Therefore, in this section we explore how to conduct a
@@ -61,7 +67,7 @@ set.seed(
 
 replicates <- 100
 
-daisie_mainland_data <- DAISIEmainland::sim_island_with_mainland(
+daisie_mainland_data <- sim_island_with_mainland(
   total_time = 1,
   m = 100,
   island_pars = c(0.5, 02.5, 50, 0.01, 0.5),
@@ -197,7 +203,7 @@ error_metrics$endemic_percent
 Overall, all of these error metrics can be computed using `calc_error()` with the simulated data and the maximum likelihood estimates.
 
 ```{r Calculate error, eval=FALSE}
-errors <- DAISIEmainland::calc_error(
+errors <- calc_error(
   daisie_mainland_data = daisie_mainland_data,
   ideal_ml = ideal_ml,
   empirical_ml = empirical_ml

--- a/inst/book/simulation_algorithm.Rmd
+++ b/inst/book/simulation_algorithm.Rmd
@@ -1,13 +1,19 @@
 # Simulation algorithm {#Simulation-algorithm}
 
+```{r message=FALSE, eval=FALSE}
+# Assume the reader knows to load the library,
+# so we do not need to include the namespace in the visible code examples
+library(DAISIEmainland)
+```
+
 The Doob-Gillespie algorithm is a stochastic exact solution that is used to
 simulate continuous-time processes, with several applications 
 in biological modelling. The Doob-Gillespie algorithm
 can be used in evolutionary biology, for example to efficiently simulate a
 birth-death process. The island-mainland simulation in the DAISIEmainland
 package uses a two-part Doob-Gillespie simulation, one for the mainland
-(`DAISIEmainland::sim_mainland`) and one for the island
-(`DAISIEmainland::sim_island`).
+(`sim_mainland`) and one for the island
+(`sim_island`).
 
 ## Mainland simulation {#Mainland-simulation}
 
@@ -27,7 +33,7 @@ set.seed(
   normal.kind = "Inversion",
   sample.kind = "Rejection"
 )
-mainland <- DAISIEmainland:::sim_mainland(
+mainland <- :sim_mainland(
   total_time = 1,
   m = 5,
   mainland_ex = 1
@@ -89,7 +95,7 @@ set.seed(
   normal.kind = "Inversion",
   sample.kind = "Rejection"
 )
-island_tbl <- DAISIEmainland:::sim_island(
+island_tbl <- :sim_island(
   total_time = 1,
   island_pars = c(1, 1, 10, 1, 1),
   mainland_clade = mainland[[1]],

--- a/inst/book/simulation_data_visualisation.Rmd
+++ b/inst/book/simulation_data_visualisation.Rmd
@@ -4,13 +4,19 @@ In the previous section (Section \@ref(Simulation-algorithm)) it showed how the 
 has a selection of plotting functions to plot the phylogenetic data of the 
 mainland and the island. 
 
+```{r message=FALSE, eval=FALSE}
+# Assume the reader knows to load the library,
+# so we do not need to include the namespace in the visible code examples
+library(DAISIEmainland)
+```
+
 ## Visualise mainland {#visualise-mainland}
 
 We simulate the same mainland system as (Section \@ref(Mainland-simulation)) and then plot the all the mainland clades using `plot_mainland`.
 
 ```{r}
 <<simulate-mainland>>
-DAISIEmainland::plot_mainland(mainland)
+plot_mainland(mainland)
 ```
 
 The above plot shows the evolutionary history of each mainland species from the
@@ -20,7 +26,7 @@ as unique species ID which are shown here as different coloured branches. The
 colours can also be changed to represent the clade a species belongs to.
 
 ```{r}
-DAISIEmainland::plot_mainland(mainland, branch_colour = "clade_id")
+plot_mainland(mainland, branch_colour = "clade_id")
 ``` 
 
 If there are many clades on the mainland it can be difficult to see when plotted
@@ -29,11 +35,11 @@ the data and plotted with `plot_mainland_clade`. Again the option of plotting
 the unique species ID or clade ID are available.
 
 ```{r, fig.align="left", fig.show="hold", out.width="45%"}
-DAISIEmainland::plot_mainland_clade(
+plot_mainland_clade(
   mainland_clade = mainland[[1]], 
   branch_colour = "unique_species_id"
 )
-DAISIEmainland::plot_mainland_clade(
+plot_mainland_clade(
   mainland_clade = mainland[[1]], 
   branch_colour = "clade_id"
 )

--- a/inst/book/summary_metrics_visualisation.Rmd
+++ b/inst/book/summary_metrics_visualisation.Rmd
@@ -1,5 +1,11 @@
 # Summary and error metrics visualisation {#Summary-error-metric-visualisation}
 
+```{r message=FALSE, eval=FALSE}
+# Assume the reader knows to load the library,
+# so we do not need to include the namespace in the visible code examples
+library(DAISIEmainland)
+```
+
 There is a range of plotting functions to visualise the summary metrics and 
 error metrics (Section\@ref(Inference-performance-error-metrics)). 
 
@@ -22,7 +28,7 @@ The simulation summary metrics we can calculate for the *ideal* and *empirical* 
 2. number of colonisation events to the island (that survived to the present) at the end of the simulation
 
 ```{r ideal-sim-num-spec}
-ideal_sim_num_spec <- DAISIEmainland::calc_num_spec(
+ideal_sim_num_spec <- calc_num_spec(
   multi_daisie_data = daisie_mainland_data$ideal_multi_daisie_data
 )
 
@@ -30,7 +36,7 @@ ideal_sim_num_spec
 ```
 
 ```{r ideal-sim-num-col}
-ideal_sim_num_col <- DAISIEmainland::calc_num_col(
+ideal_sim_num_col <- calc_num_col(
   multi_daisie_data = daisie_mainland_data$ideal_multi_daisie_data
 )
 
@@ -38,7 +44,7 @@ ideal_sim_num_col
 ```
 
 ```{r empirical-sim-num-spec}
-empirical_sim_num_spec <- DAISIEmainland::calc_num_spec(
+empirical_sim_num_spec <- calc_num_spec(
   multi_daisie_data = daisie_mainland_data$empirical_multi_daisie_data
 )
 
@@ -46,7 +52,7 @@ empirical_sim_num_spec
 ```
 
 ```{r empirical-sim-num-col}
-empirical_sim_num_col <- DAISIEmainland::calc_num_col(
+empirical_sim_num_col <- calc_num_col(
   multi_daisie_data = daisie_mainland_data$empirical_multi_daisie_data
 )
 
@@ -71,7 +77,7 @@ error metrics can be plotted across different rates to determine how the error
 varies with faster or slower mainland evolutionary dynamics.
 
 ```{r, read-analysis-results}
-analysis_results <- DAISIEmainland::read_analysis_results(
+analysis_results <- read_analysis_results(
   data_folder_path = system.file(
     "/inst/book/data/param_sets/", 
     package = "DAISIEmainland"


### PR DESCRIPTION
Here I secretly load the `DAISIEmainland` package to remove the need to write `DAISIEmainland::`, resulting in less cluttered code. 

I imagined this would not always work out well, but AFAICS, it is always fine. Of course, you are boss, so feel free to disagree :-)