### PR TITLE
Change label, fix #77

### DIFF
--- a/R/colonist_species_type_to_str.R
+++ b/R/colonist_species_type_to_str.R
@@ -4,8 +4,8 @@
 #'
 #' Value|String
 #' -----|-----------------------------
-#' `A`  | `Colonist after anagenesis`
-#' `C`  | `Colonist after cladogenesis`
+#' `A`  | `Anagenetic recolonist`
+#' `C`  | `Cladogenetic recolonist`
 #'
 #' @inheritParams default_params_doc
 #'
@@ -19,9 +19,9 @@
 colonist_species_type_to_str <- function(colonist_species_type) { # nolint Indeed a long internal function name
   testthat::expect_equal(length(colonist_species_type), 1)
   if (colonist_species_type == "A") {
-    return("Colonist after anagenesis")
+    return("Anagenetic recolonist")
   } else if (colonist_species_type == "C") {
-    return("Colonist after cladogenesis")
+    return("Cladogenetic recolonist")
   }
   stop(
     "Invalid 'colonist_species_type' with value ", colonist_species_type, " \n",

--- a/man/colonist_species_type_to_str.Rd
+++ b/man/colonist_species_type_to_str.Rd
@@ -15,8 +15,8 @@ Convert a \code{colonist_species_type} to a string:
 \details{
 \tabular{ll}{
    Value \tab String \cr
-   \code{A} \tab \verb{Colonist after anagenesis} \cr
-   \code{C} \tab \verb{Colonist after cladogenesis} \cr
+   \code{A} \tab \verb{Anagenetic recolonist} \cr
+   \code{C} \tab \verb{Cladogenetic recolonist} \cr
 }
 }
 \examples{

--- a/tests/testthat/test-colonist_species_type_to_str.R
+++ b/tests/testthat/test-colonist_species_type_to_str.R
@@ -1,6 +1,6 @@
 test_that("use", {
-  expect_equal(colonist_species_type_to_str("A"), "Colonist after anagenesis")
-  expect_equal(colonist_species_type_to_str("C"), "Colonist after cladogenesis")
+  expect_equal(colonist_species_type_to_str("A"), "Anagenetic recolonist")
+  expect_equal(colonist_species_type_to_str("C"), "Cladogenetic recolonist  ")
   expect_error(colonist_species_type_to_str(""))
   expect_error(colonist_species_type_to_str("B"))
   expect_error(colonist_species_type_to_str(c("A", "V")))

--- a/tests/testthat/test-colonist_species_type_to_str.R
+++ b/tests/testthat/test-colonist_species_type_to_str.R
@@ -1,6 +1,6 @@
 test_that("use", {
   expect_equal(colonist_species_type_to_str("A"), "Anagenetic recolonist")
-  expect_equal(colonist_species_type_to_str("C"), "Cladogenetic recolonist  ")
+  expect_equal(colonist_species_type_to_str("C"), "Cladogenetic recolonist")
   expect_error(colonist_species_type_to_str(""))
   expect_error(colonist_species_type_to_str("B"))
   expect_error(colonist_species_type_to_str(c("A", "V")))


### PR DESCRIPTION
Fixed #77, that is, this request:

> I see that on the plot island output the legend it says Colonist after anagenesis or Colonist after cladogenesis, 
> would it be possible to change these to Anagenetic recolonist and Cladogenetic recolonist?
